### PR TITLE
Add Snapcast RPC client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # JSONRPC
-JSON RPC Control API
+
+This repository contains a simple Python client for the Snapcast JSON-RPC control API.
+
+## Requirements
+
+- Python 3.11+
+- `requests` library (`pip install requests`)
+
+## Usage
+
+The provided script `snapcast_client.py` connects to the Snapcast server at `192.168.1.70` on port `1780` and calls `Server.GetStatus` via HTTP JSON-RPC. The resulting JSON is printed to the console.
+
+```bash
+python3 snapcast_client.py
+```
+
+If the server is unreachable or returns an error, an error message will be printed instead.
+
+The API reference is available at <https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md>.

--- a/snapcast_client.py
+++ b/snapcast_client.py
@@ -1,0 +1,47 @@
+import json
+import requests
+
+class SnapcastRPCClient:
+    def __init__(self, host="192.168.1.70", port=1780):
+        self.url = f"http://{host}:{port}/jsonrpc"
+        self.session = requests.Session()
+        self.request_id = 0
+
+    def call(self, method, params=None):
+        self.request_id += 1
+        payload = {
+            "id": self.request_id,
+            "jsonrpc": "2.0",
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+        try:
+            response = self.session.post(
+                self.url,
+                json=payload,
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                timeout=5,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"RPC request failed: {exc}") from exc
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Invalid JSON response") from exc
+        if "error" in data:
+            raise RuntimeError(f"RPC error: {data['error']}")
+        return data.get("result")
+
+def main():
+    client = SnapcastRPCClient()
+    try:
+        status = client.call("Server.GetStatus")
+    except Exception as exc:
+        print(f"Failed to get server status: {exc}")
+    else:
+        print(json.dumps(status, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a simple client script `snapcast_client.py` for Snapcast's JSON-RPC API
- document requirements and usage in README

## Testing
- `python3 -m py_compile snapcast_client.py`
- `python3 snapcast_client.py` *(fails: 403 Client Error: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c0a8a243c832a8e05701ce796bd8e