### PR TITLE
Add simple Flask web interface for Snapcast clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # JSONRPC
 
-This repository contains a simple Python client for the Snapcast JSON-RPC control API.
+This repository contains a simple Python client for the Snapcast JSON-RPC control API and a minimal Flask-based web interface.
 
 ## Requirements
 
 - Python 3.11+
 - `requests` library (`pip install requests`)
+- `Flask` (`pip install Flask`)
 
-## Usage
+## Command Line Usage
 
-The provided script `snapcast_client.py` connects to the Snapcast server at `192.168.1.70` on port `1780` and calls `Server.GetStatus` via HTTP JSON-RPC. The resulting JSON is printed to the console.
+The script `snapcast_client.py` connects to the Snapcast server at `192.168.1.70` on port `1780` and calls `Server.GetStatus` via HTTP JSON-RPC. The resulting JSON is printed to the console.
 
 ```bash
 python3 snapcast_client.py
 ```
 
 If the server is unreachable or returns an error, an error message will be printed instead.
+
+## Web Interface
+
+Run the Flask application to view connected clients and change their streams:
+
+```bash
+python3 web_app.py
+```
+
+Visit `http://localhost:5000` in your browser. The page lists all clients with the stream they are currently connected to. A drop-down allows selecting a different stream for each client.
 
 The API reference is available at <https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md>.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+    <title>Snapcast Clients</title>
+</head>
+<body>
+    <h1>Snapcast Clients</h1>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    <table border="1" cellpadding="5" cellspacing="0">
+        <tr>
+            <th>Client</th>
+            <th>Current Stream</th>
+            <th>Change Stream</th>
+        </tr>
+        {% for client in clients %}
+        <tr>
+            <td>{{ client.name }}</td>
+            <td>{{ client.stream_id }}</td>
+            <td>
+                <form action="{{ url_for('change_stream') }}" method="post">
+                    <input type="hidden" name="group_id" value="{{ client.group_id }}">
+                    <select name="stream_id">
+                        {% for stream in streams %}
+                            <option value="{{ stream.id }}" {% if stream.id == client.stream_id %}selected{% endif %}>{{ stream.id }}</option>
+                        {% endfor %}
+                    </select>
+                    <input type="submit" value="Set">
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,45 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+import os
+from snapcast_client import SnapcastRPCClient
+
+app = Flask(__name__)
+app.secret_key = os.urandom(24)
+
+client = SnapcastRPCClient()
+
+@app.route('/')
+def index():
+    try:
+        status = client.call('Server.GetStatus')
+    except Exception as exc:
+        return f'Error fetching status: {exc}', 500
+
+    streams = status.get('server', {}).get('streams', [])
+    groups = status.get('server', {}).get('groups', [])
+
+    # Flatten clients with group and stream info
+    clients = []
+    for group in groups:
+        stream_id = group.get('stream_id')
+        group_id = group.get('id')
+        for c in group.get('clients', []):
+            name = c.get('config', {}).get('name') or c.get('host', {}).get('name') or c.get('id')
+            clients.append({'id': c.get('id'), 'name': name, 'group_id': group_id, 'stream_id': stream_id})
+    return render_template('index.html', clients=clients, streams=streams)
+
+@app.route('/change_stream', methods=['POST'])
+def change_stream():
+    group_id = request.form.get('group_id')
+    stream_id = request.form.get('stream_id')
+    if not group_id or not stream_id:
+        flash('Invalid request')
+        return redirect(url_for('index'))
+    try:
+        client.call('Group.SetStream', {'id': group_id, 'stream_id': stream_id})
+        flash(f'Stream changed to {stream_id} for group {group_id}')
+    except Exception as exc:
+        flash(f'Error setting stream: {exc}')
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- add a minimal web app (web_app.py) using Flask
- list clients and their current stream and allow changing streams
- provide HTML template for the interface
- update README with new instructions

## Testing
- `python3 -m py_compile snapcast_client.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c1e7b0894832a8c24b537485568eb