### PR TITLE
Improve Snapcast RPC client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This repository contains a simple Python client for the Snapcast JSON-RPC contro
 
 ## Command Line Usage
 
-The script `snapcast_client.py` connects to the Snapcast server at `192.168.1.70` on port `1780` and calls `Server.GetStatus` via HTTP JSON-RPC. The resulting JSON is printed to the console.
+The script `snapcast_client.py` connects to the Snapcast server (defaults to
+`192.168.1.70:1780`) and calls `Server.GetStatus` via HTTP JSON-RPC.  Host,
+port and request timeout can be changed with the environment variables
+`SNAPCAST_HOST`, `SNAPCAST_PORT` and `SNAPCAST_TIMEOUT` respectively.
+The resulting JSON is printed to the console.
 
 ```bash
 python3 snapcast_client.py
@@ -20,7 +24,16 @@ If the server is unreachable or returns an error, an error message will be print
 
 ## Web Interface
 
-Run the Flask application to view connected clients and change their streams:
+Run the Flask application to view connected clients and change their streams.
+The same environment variables used by ``snapcast_client.py`` can be set to
+point the web interface at a different Snapcast server or to adjust the
+request timeout. Example:
+
+```bash
+SNAPCAST_HOST=192.168.1.50 SNAPCAST_TIMEOUT=15 python3 web_app.py
+```
+
+Or simply:
 
 ```bash
 python3 web_app.py

--- a/snapcast_client.py
+++ b/snapcast_client.py
@@ -1,8 +1,21 @@
 import json
+import os
 import requests
 
 class SnapcastRPCClient:
-    def __init__(self, host="192.168.1.70", port=1780):
+    def __init__(self, host=None, port=None, timeout=None):
+        """Create a new RPC client.
+
+        Parameters can be provided explicitly or via the environment
+        variables ``SNAPCAST_HOST``, ``SNAPCAST_PORT`` and
+        ``SNAPCAST_TIMEOUT``. If not specified, reasonable defaults are
+        used. ``timeout`` controls the total request timeout in seconds.
+        """
+
+        host = host or os.environ.get("SNAPCAST_HOST", "192.168.1.70")
+        port = int(port or os.environ.get("SNAPCAST_PORT", 1780))
+        self.timeout = float(timeout or os.environ.get("SNAPCAST_TIMEOUT", 10))
+
         self.url = f"http://{host}:{port}/jsonrpc"
         self.session = requests.Session()
         self.request_id = 0
@@ -21,7 +34,7 @@ class SnapcastRPCClient:
                 self.url,
                 json=payload,
                 headers={"Content-Type": "application/json", "Accept": "application/json"},
-                timeout=5,
+                timeout=self.timeout,
             )
             response.raise_for_status()
         except requests.RequestException as exc:


### PR DESCRIPTION
## Summary
- allow configuring Snapcast host, port and timeout through parameters or environment variables
- mention these variables in the README with an example usage

## Testing
- `python -m py_compile snapcast_client.py web_app.py`
- `pip install requests flask`
- `python3 snapcast_client.py` *(fails: 403 Client Error: Forbidden for url: http://192.168.1.70:1780/jsonrpc)*

------
https://chatgpt.com/codex/tasks/task_e_686c28bfaf30832aa3720ce1b5f02166