### PR TITLE
Improve AudioBrane interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,6 @@ python3 web_app.py
 
 Visit `http://localhost:5000` in your browser. The page lists all clients with the stream they are currently connected to. A drop-down allows selecting a different stream for each client.
 
+The interface, now titled **AudioBrane**, features a simple illustration of a brain with musical notes. A checkbox lets you hide clients that are not connected.
+
 The API reference is available at <https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md>.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,10 +1,77 @@
 <!doctype html>
 <html>
 <head>
-    <title>Snapcast Clients</title>
+    <meta charset="utf-8">
+    <title>AudioBrane</title>
+    <style>
+        body {
+            font-family: "Segoe UI", Tahoma, sans-serif;
+            background: #f9f9f9;
+            color: #333;
+            margin: 0;
+            padding: 20px;
+        }
+
+        h1 {
+            margin-top: 0;
+        }
+
+        .logo {
+            position: relative;
+            display: inline-block;
+            margin-bottom: 20px;
+        }
+
+        .logo img.brain {
+            width: 80px;
+            height: auto;
+        }
+
+        .logo img.notes {
+            position: absolute;
+            top: -10px;
+            right: -10px;
+            width: 40px;
+            height: auto;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            background: white;
+        }
+
+        th, td {
+            padding: 8px 12px;
+            border: 1px solid #ccc;
+        }
+
+        th {
+            background: #f0f0f0;
+            text-align: left;
+        }
+
+        .volume-slider {
+            width: 120px;
+        }
+
+        .settings {
+            margin-bottom: 20px;
+        }
+    </style>
 </head>
 <body>
-    <h1>Snapcast Clients</h1>
+    <div class="logo">
+        <img class="brain" src="https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f9e0.svg" alt="brain">
+        <img class="notes" src="https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f3b5.svg" alt="music notes">
+    </div>
+    <h1>AudioBrane</h1>
+    <form class="settings" method="get">
+        <label>
+            <input type="checkbox" name="show_disconnected" value="1" {% if show_disconnected %}checked{% endif %}> Show disconnected clients
+        </label>
+        <button type="submit">Apply</button>
+    </form>
     {% with messages = get_flashed_messages() %}
       {% if messages %}
         <ul>
@@ -14,11 +81,6 @@
         </ul>
       {% endif %}
     {% endwith %}
-    <style>
-        .volume-slider {
-            width: 120px;
-        }
-    </style>
     <table border="1" cellpadding="5" cellspacing="0">
         <tr>
             <th>Client</th>

--- a/web_app.py
+++ b/web_app.py
@@ -9,6 +9,7 @@ client = SnapcastRPCClient()
 
 @app.route('/')
 def index():
+    show_disconnected = request.args.get('show_disconnected') == '1'
     try:
         status = client.call('Server.GetStatus')
     except Exception as exc:
@@ -23,6 +24,9 @@ def index():
         stream_id = group.get('stream_id')
         group_id = group.get('id')
         for c in group.get('clients', []):
+            connected = c.get('connected', True)
+            if not show_disconnected and not connected:
+                continue
             name = c.get('config', {}).get('name') or c.get('host', {}).get('name') or c.get('id')
             volume_cfg = c.get('config', {}).get('volume', {})
             clients.append({
@@ -33,7 +37,7 @@ def index():
                 'volume_percent': volume_cfg.get('percent'),
                 'volume_muted': volume_cfg.get('muted'),
             })
-    return render_template('index.html', clients=clients, streams=streams)
+    return render_template('index.html', clients=clients, streams=streams, show_disconnected=show_disconnected)
 
 @app.route('/change_stream', methods=['POST'])
 def change_stream():


### PR DESCRIPTION
## Summary
- polish look and feel of web UI
- rename site to **AudioBrane** and add brain & music notes logo
- allow toggling visibility of disconnected clients

## Testing
- `python3 -m py_compile snapcast_client.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c30e7fd1c832aab49a9d12710bf83