### PR TITLE
Add client renaming and stream info

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -58,6 +58,15 @@
         .settings {
             margin-bottom: 20px;
         }
+
+        .stream-buttons button {
+            margin: 2px;
+        }
+
+        .stream-buttons button.selected {
+            background: #4CAF50;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -86,26 +95,47 @@
             <th>Client</th>
             <th>Current Stream</th>
             <th>Change Stream</th>
+            <th>Change Name</th>
             <th>Volume</th>
         </tr>
         {% for client in clients %}
         <tr>
             <td>{{ client.name }}</td>
             <td>{{ client.stream_id }}</td>
-            <td>
+            <td class="stream-buttons">
                 <form action="{{ url_for('change_stream') }}" method="post">
                     <input type="hidden" name="group_id" value="{{ client.group_id }}">
-                    <select name="stream_id">
-                        {% for stream in streams %}
-                            <option value="{{ stream.id }}" {% if stream.id == client.stream_id %}selected{% endif %}>{{ stream.id }}</option>
-                        {% endfor %}
-                    </select>
-                    <input type="submit" value="Set">
+                    {% for stream in streams %}
+                        <button type="submit" name="stream_id" value="{{ stream.id }}" class="{% if stream.id == client.stream_id %}selected{% endif %}">{{ stream.id }}</button>
+                    {% endfor %}
+                </form>
+            </td>
+            <td>
+                <form action="{{ url_for('change_name') }}" method="post">
+                    <input type="hidden" name="client_id" value="{{ client.id }}">
+                    <input type="text" name="name" value="{{ client.name }}">
+                    <input type="submit" value="Rename">
                 </form>
             </td>
             <td>
                 <input type="range" min="0" max="100" step="1" class="volume-slider" data-client="{{ client.id }}" value="{% if client.volume_muted %}0{% else %}{{ client.volume_percent }}{% endif %}">
             </td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <h2>Streams</h2>
+    <table border="1" cellpadding="5" cellspacing="0">
+        <tr>
+            <th>Stream</th>
+            <th>Status</th>
+            <th>Source</th>
+        </tr>
+        {% for stream in streams %}
+        <tr>
+            <td>{{ stream.id }}</td>
+            <td>{{ stream.status }}</td>
+            <td>{{ stream.uri.raw }}</td>
         </tr>
         {% endfor %}
     </table>

--- a/web_app.py
+++ b/web_app.py
@@ -54,6 +54,21 @@ def change_stream():
     return redirect(url_for('index'))
 
 
+@app.route('/change_name', methods=['POST'])
+def change_name():
+    client_id = request.form.get('client_id')
+    name = request.form.get('name')
+    if not client_id or name is None:
+        flash('Invalid request')
+        return redirect(url_for('index'))
+    try:
+        client.call('Client.SetName', {'id': client_id, 'name': name})
+        flash(f'Name changed to {name} for {client_id}')
+    except Exception as exc:
+        flash(f'Error setting name: {exc}')
+    return redirect(url_for('index'))
+
+
 @app.route('/set_volume', methods=['POST'])
 def set_volume():
     client_id = request.form.get('client_id')


### PR DESCRIPTION
## Summary
- enable renaming Snapcast clients
- switch stream selection to buttons
- display current streams and their status

## Testing
- `python3 -m py_compile snapcast_client.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c32ac345c832a9c0b887d6c4d4b6b