### PR TITLE
Update client UI and stream info

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Or simply:
 python3 web_app.py
 ```
 
-Visit `http://localhost:5000` in your browser. The page lists all clients with the stream they are currently connected to. A drop-down allows selecting a different stream for each client.
+Visit `http://localhost:5000` in your browser. The page lists all clients with inline name editing and buttons to switch streams for each client.
 
-The interface, now titled **AudioBrane**, features a simple illustration of a brain with musical notes. A checkbox lets you hide clients that are not connected.
+The interface, now titled **AudioBrane**, features a simple illustration of a brain with musical notes. A checkbox lets you hide clients that are not connected. The streams table lists each stream with its current status and the song that is playing.
 
 The API reference is available at <https://github.com/badaix/snapcast/blob/develop/doc/json_rpc_api/control.md>.

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,6 +67,12 @@
             background: #4CAF50;
             color: white;
         }
+
+        .client-name-form {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
     </style>
 </head>
 <body>
@@ -93,28 +99,24 @@
     <table border="1" cellpadding="5" cellspacing="0">
         <tr>
             <th>Client</th>
-            <th>Current Stream</th>
             <th>Change Stream</th>
-            <th>Change Name</th>
             <th>Volume</th>
         </tr>
         {% for client in clients %}
         <tr>
-            <td>{{ client.name }}</td>
-            <td>{{ client.stream_id }}</td>
+            <td>
+                <form action="{{ url_for('change_name') }}" method="post" class="client-name-form">
+                    <input type="hidden" name="client_id" value="{{ client.id }}">
+                    <input type="text" name="name" value="{{ client.name }}">
+                    <button type="submit">Rename</button>
+                </form>
+            </td>
             <td class="stream-buttons">
                 <form action="{{ url_for('change_stream') }}" method="post">
                     <input type="hidden" name="group_id" value="{{ client.group_id }}">
                     {% for stream in streams %}
                         <button type="submit" name="stream_id" value="{{ stream.id }}" class="{% if stream.id == client.stream_id %}selected{% endif %}">{{ stream.id }}</button>
                     {% endfor %}
-                </form>
-            </td>
-            <td>
-                <form action="{{ url_for('change_name') }}" method="post">
-                    <input type="hidden" name="client_id" value="{{ client.id }}">
-                    <input type="text" name="name" value="{{ client.name }}">
-                    <input type="submit" value="Rename">
                 </form>
             </td>
             <td>
@@ -129,13 +131,13 @@
         <tr>
             <th>Stream</th>
             <th>Status</th>
-            <th>Source</th>
+            <th>Current Song</th>
         </tr>
         {% for stream in streams %}
         <tr>
             <td>{{ stream.id }}</td>
             <td>{{ stream.status }}</td>
-            <td>{{ stream.uri.raw }}</td>
+            <td>{{ stream.current_song }}</td>
         </tr>
         {% endfor %}
     </table>

--- a/web_app.py
+++ b/web_app.py
@@ -16,6 +16,10 @@ def index():
         return f'Error fetching status: {exc}', 500
 
     streams = status.get('server', {}).get('streams', [])
+    for stream in streams:
+        metadata = stream.get('metadata', {})
+        song = metadata.get('title') or metadata.get('name') or metadata.get('file', '')
+        stream['current_song'] = song
     groups = status.get('server', {}).get('groups', [])
 
     # Flatten clients with group, stream and volume info


### PR DESCRIPTION
## Summary
- integrate rename field with client name
- drop redundant "Current Stream" column
- display current song per stream in UI
- document updated interface

## Testing
- `python3 -m py_compile web_app.py snapcast_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3454b048832ab133cf901e25f40f