### PR TITLE
Display stream tiles with playback controls

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,43 @@
             text-align: left;
         }
 
+        .streams-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .stream-tile {
+            background: white;
+            border: 1px solid #ccc;
+            padding: 10px;
+            width: 220px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        .stream-tile img {
+            width: 200px;
+            height: 200px;
+            object-fit: cover;
+            display: block;
+            margin-bottom: 5px;
+        }
+
+        .stream-tile .controls button {
+            margin-right: 5px;
+        }
+
+        .no-art {
+            width: 200px;
+            height: 200px;
+            background: #eee;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 5px;
+            color: #999;
+        }
+
         .volume-slider {
             width: 120px;
         }
@@ -127,20 +164,27 @@
     </table>
 
     <h2>Streams</h2>
-    <table border="1" cellpadding="5" cellspacing="0">
-        <tr>
-            <th>Stream</th>
-            <th>Status</th>
-            <th>Current Song</th>
-        </tr>
+    <div class="streams-container">
         {% for stream in streams %}
-        <tr>
-            <td>{{ stream.id }}</td>
-            <td>{{ stream.status }}</td>
-            <td>{{ stream.current_song }}</td>
-        </tr>
+        <div class="stream-tile">
+            {% if stream.album_art %}
+            <img src="{{ stream.album_art }}" alt="Album Art">
+            {% else %}
+            <div class="no-art">No Art</div>
+            {% endif %}
+            <h3>{{ stream.id }}</h3>
+            <p>Status: {{ stream.status }}</p>
+            {% if stream.title %}<p>{{ stream.title }}</p>{% endif %}
+            {% if stream.artist %}<p>Artist: {{ stream.artist }}</p>{% endif %}
+            {% if stream.album %}<p>Album: {{ stream.album }}</p>{% endif %}
+            <div class="controls">
+                <button data-stream="{{ stream.id }}" data-command="previous">Prev</button>
+                <button data-stream="{{ stream.id }}" data-command="playPause">Play/Pause</button>
+                <button data-stream="{{ stream.id }}" data-command="next">Next</button>
+            </div>
+        </div>
         {% endfor %}
-    </table>
+    </div>
 
     <script>
         document.querySelectorAll('.volume-slider').forEach(function(slider) {
@@ -162,6 +206,23 @@
             }
             slider.addEventListener('mouseup', sendVolume);
             slider.addEventListener('touchend', sendVolume);
+        });
+
+        document.querySelectorAll('.stream-tile .controls button').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var params = new URLSearchParams();
+                params.append('stream_id', btn.dataset.stream);
+                params.append('command', btn.dataset.command);
+                fetch('{{ url_for('stream_control') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params.toString()
+                }).then(function() {
+                    window.location.reload();
+                });
+            });
         });
     </script>
 </body>

--- a/web_app.py
+++ b/web_app.py
@@ -1,11 +1,36 @@
 from flask import Flask, render_template, request, redirect, url_for, flash
 import os
+import json
+import urllib.parse
+import urllib.request
 from snapcast_client import SnapcastRPCClient
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
 
 client = SnapcastRPCClient()
+
+album_art_cache = {}
+
+
+def fetch_album_art(artist, album):
+    key = (artist, album)
+    if key in album_art_cache:
+        return album_art_cache[key]
+    try:
+        search_url = (
+            "https://musicbrainz.org/ws/2/release/?query=artist:%s%%20AND%%20release:%s&fmt=json&limit=1"
+            % (urllib.parse.quote(artist), urllib.parse.quote(album))
+        )
+        with urllib.request.urlopen(search_url, timeout=5) as resp:
+            data = json.load(resp)
+        release_id = data["releases"][0]["id"]
+        cover_url = f"https://coverartarchive.org/release/{release_id}/front-250"
+        album_art_cache[key] = cover_url
+        return cover_url
+    except Exception:
+        album_art_cache[key] = None
+        return None
 
 @app.route('/')
 def index():
@@ -18,8 +43,19 @@ def index():
     streams = status.get('server', {}).get('streams', [])
     for stream in streams:
         metadata = stream.get('metadata', {})
-        song = metadata.get('title') or metadata.get('name') or metadata.get('file', '')
-        stream['current_song'] = song
+        title = metadata.get('title') or metadata.get('name') or metadata.get('file', '')
+        artist = metadata.get('artist')
+        if isinstance(artist, list):
+            artist = ", ".join(artist)
+        album = metadata.get('album')
+        stream['title'] = title
+        stream['artist'] = artist
+        stream['album'] = album
+        stream['current_song'] = title
+        if artist and album:
+            stream['album_art'] = fetch_album_art(artist, album)
+        else:
+            stream['album_art'] = None
     groups = status.get('server', {}).get('groups', [])
 
     # Flatten clients with group, stream and volume info
@@ -100,6 +136,19 @@ def set_volume():
     except Exception as exc:
         flash(f'Error setting volume: {exc}')
     return redirect(url_for('index'))
+
+
+@app.route('/stream_control', methods=['POST'])
+def stream_control():
+    stream_id = request.form.get('stream_id')
+    command = request.form.get('command')
+    if not stream_id or not command:
+        return 'Invalid request', 400
+    try:
+        client.call('Stream.Control', {'id': stream_id, 'command': command})
+    except Exception as exc:
+        return f'Error: {exc}', 500
+    return 'ok'
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- extract more metadata from Snapcast streams
- query MusicBrainz/Cover Art Archive for album art
- add endpoint to send `Stream.Control` commands
- replace streams table with grid of tiles including album art and playback buttons

## Testing
- `python3 -m py_compile web_app.py snapcast_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3642cb24832ab7186dc755e6a6d9