### PR TITLE
Improve logging for stream control

### DIFF
--- a/snapcast_client.py
+++ b/snapcast_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 import websocket
 
 class SnapcastRPCClient:
@@ -28,6 +29,7 @@ class SnapcastRPCClient:
         }
         if params is not None:
             payload["params"] = params
+        logging.info("Sending RPC payload: %s", payload)
         try:
             ws = websocket.create_connection(self.url, timeout=self.timeout)
             ws.send(json.dumps(payload))
@@ -44,6 +46,7 @@ class SnapcastRPCClient:
             data = json.loads(response)
         except json.JSONDecodeError as exc:
             raise RuntimeError("Invalid JSON response") from exc
+        logging.info("RPC response: %s", data)
         if "error" in data:
             raise RuntimeError(f"RPC error: {data['error']}")
         return data.get("result")

--- a/web_app.py
+++ b/web_app.py
@@ -3,10 +3,12 @@ import os
 import json
 import urllib.parse
 import urllib.request
+import logging
 from snapcast_client import SnapcastRPCClient
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')
 
 client = SnapcastRPCClient()
 
@@ -142,11 +144,15 @@ def set_volume():
 def stream_control():
     stream_id = request.form.get('stream_id')
     command = request.form.get('command')
+    app.logger.info('stream_control POST: stream_id=%s command=%s', stream_id, command)
     if not stream_id or not command:
+        app.logger.warning('Invalid stream_control request')
         return 'Invalid request', 400
     try:
-        client.call('Stream.Control', {'id': stream_id, 'command': command})
+        result = client.call('Stream.Control', {'id': stream_id, 'command': command})
+        app.logger.info('Stream.Control result: %s', result)
     except Exception as exc:
+        app.logger.exception('Stream.Control failed')
         return f'Error: {exc}', 500
     return 'ok'
 


### PR DESCRIPTION
## Summary
- configure Python logging in `web_app.py`
- add logging to `/stream_control` endpoint
- log requests/responses in `SnapcastRPCClient`

## Testing
- `python -m py_compile web_app.py snapcast_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3e985120832a8b6820c98242e52b