### PR TITLE
Remove stream controls, silence logging, fix album art

### DIFF
--- a/snapcast_client.py
+++ b/snapcast_client.py
@@ -29,7 +29,7 @@ class SnapcastRPCClient:
         }
         if params is not None:
             payload["params"] = params
-        logging.info("Sending RPC payload: %s", payload)
+        logging.debug("Sending RPC payload: %s", payload)
         try:
             ws = websocket.create_connection(self.url, timeout=self.timeout)
             ws.send(json.dumps(payload))
@@ -46,7 +46,7 @@ class SnapcastRPCClient:
             data = json.loads(response)
         except json.JSONDecodeError as exc:
             raise RuntimeError("Invalid JSON response") from exc
-        logging.info("RPC response: %s", data)
+        logging.debug("RPC response: %s", data)
         if "error" in data:
             raise RuntimeError(f"RPC error: {data['error']}")
         return data.get("result")

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,9 +73,6 @@
             margin-bottom: 5px;
         }
 
-        .stream-tile .controls button {
-            margin-right: 5px;
-        }
 
         .no-art {
             width: 200px;
@@ -177,11 +174,7 @@
             {% if stream.title %}<p>{{ stream.title }}</p>{% endif %}
             {% if stream.artist %}<p>Artist: {{ stream.artist }}</p>{% endif %}
             {% if stream.album %}<p>Album: {{ stream.album }}</p>{% endif %}
-            <div class="controls">
-                <button data-stream="{{ stream.id }}" data-command="previous">Prev</button>
-                <button data-stream="{{ stream.id }}" data-command="playPause">Play/Pause</button>
-                <button data-stream="{{ stream.id }}" data-command="next">Next</button>
-            </div>
+            
         </div>
         {% endfor %}
     </div>
@@ -208,22 +201,6 @@
             slider.addEventListener('touchend', sendVolume);
         });
 
-        document.querySelectorAll('.stream-tile .controls button').forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                var params = new URLSearchParams();
-                params.append('stream_id', btn.dataset.stream);
-                params.append('command', btn.dataset.command);
-                fetch('{{ url_for('stream_control') }}', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded'
-                    },
-                    body: params.toString()
-                }).then(function() {
-                    window.location.reload();
-                });
-            });
-        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- quiet default logging output
- use MusicBrainz with a user agent so album covers load
- drop the unused `/stream_control` route and buttons

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c40465a70832a8408d39b78f97d91