### PR TITLE
Show raw stream metadata

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -61,13 +61,13 @@
             background: white;
             border: 1px solid #ccc;
             padding: 10px;
-            width: 220px;
+            width: 320px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
 
         .stream-tile img {
-            width: 200px;
-            height: 200px;
+            width: 300px;
+            height: 300px;
             object-fit: cover;
             display: block;
             margin-bottom: 5px;
@@ -75,14 +75,20 @@
 
 
         .no-art {
-            width: 200px;
-            height: 200px;
+            width: 300px;
+            height: 300px;
             background: #eee;
             display: flex;
             align-items: center;
             justify-content: center;
             margin-bottom: 5px;
             color: #999;
+        }
+
+        .metadata {
+            font-size: 12px;
+            white-space: pre-wrap;
+            overflow-x: auto;
         }
 
         .volume-slider {
@@ -174,7 +180,8 @@
             {% if stream.title %}<p>{{ stream.title }}</p>{% endif %}
             {% if stream.artist %}<p>Artist: {{ stream.artist }}</p>{% endif %}
             {% if stream.album %}<p>Album: {{ stream.album }}</p>{% endif %}
-            
+            <pre class="metadata">{{ stream.raw_metadata }}</pre>
+
         </div>
         {% endfor %}
     </div>

--- a/web_app.py
+++ b/web_app.py
@@ -73,6 +73,7 @@ def index():
         art_url = metadata.get('artUrl')
         art_data = metadata.get('artData', {})
 
+        stream['raw_metadata'] = json.dumps(metadata, indent=2)
         stream['title'] = title
         stream['artist'] = artist
         stream['album'] = album


### PR DESCRIPTION
## Summary
- display raw stream metadata in each stream tile
- enlarge stream tiles for better metadata display

## Testing
- `python3 -m py_compile web_app.py snapcast_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686c47665640832a9f04ff6da04d40b1