### PR TITLE
Add verbose debug logging for streams and album art

### DIFF
--- a/snapcast_client.py
+++ b/snapcast_client.py
@@ -31,10 +31,14 @@ class SnapcastRPCClient:
             payload["params"] = params
         logging.debug("Sending RPC payload: %s", payload)
         try:
+            logging.debug("Connecting to Snapcast server at %s", self.url)
             ws = websocket.create_connection(self.url, timeout=self.timeout)
+            logging.debug("Connection established")
             ws.send(json.dumps(payload))
+            logging.debug("Payload sent, waiting for response")
             ws.settimeout(self.timeout)
             response = ws.recv()
+            logging.debug("Raw response: %s", response)
         except websocket.WebSocketException as exc:
             raise RuntimeError(f"RPC request failed: {exc}") from exc
         finally:


### PR DESCRIPTION
## Summary
- add detailed WebSocket connection logs in `SnapcastRPCClient`
- log album art search URL, release ID, and cover URL in `fetch_album_art`
- log RPC call intent and raw stream/group data in the web app
- log more info when determining album art and when adding clients

## Testing
- `python3 -m py_compile snapcast_client.py web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c4a27e62c832a99e18c7a6fa24cc7