### PR TITLE
Fix rename icon display and quoting

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -129,7 +129,8 @@
         <tr>
             <td>
                 {{ client.name }}
-                <span class="rename-icon" title="Rename" onclick="openRenameModal('{{ client.id }}', '{{ client.name }}')">\u270E</span>
+                <span class="rename-icon" title="Rename"
+                      onclick="openRenameModal('{{ client.id|escapejs }}', '{{ client.name|escapejs }}')">&#x270E;</span>
             </td>
             <td class="stream-buttons">
                 <form action="{{ url_for('change_stream') }}" method="post">


### PR DESCRIPTION
## Summary
- render pencil icon using HTML entity
- escape client info in JS call to handle special characters

## Testing
- `python3 -m py_compile web_app.py snapcast_client.py`


------
https://chatgpt.com/codex/tasks/task_e_686c517f33a8832aa3150c62aa5f9e49